### PR TITLE
Fix typo in Intune remediate sample

### DIFF
--- a/src_Set-OutlookSignatures/sample code/Intune-SetOutlookSignatures-Remediate.ps1
+++ b/src_Set-OutlookSignatures/sample code/Intune-SetOutlookSignatures-Remediate.ps1
@@ -100,7 +100,7 @@ try {
             }
             $ProgressPreference = $OldProgressPreference
 
-            @(@(Get-ChildItem -LiteralPath $SoftwarePath -Recurse -Force) | Select-Object *, @{Name = 'FolderDepth'; Expression = { $_.DirectoryName.Split('\').Count } } | Sort-Object -Culuture 127 -Descending -Property FolderDepth, FullName) | Remove-Item -Force -Recurse
+            @(@(Get-ChildItem -LiteralPath $SoftwarePath -Recurse -Force) | Select-Object *, @{Name = 'FolderDepth'; Expression = { $_.DirectoryName.Split('\').Count } } | Sort-Object -Culture 127 -Descending -Property FolderDepth, FullName) | Remove-Item -Force -Recurse
 
             Add-Type -Assembly System.IO.Compression.FileSystem
 


### PR DESCRIPTION
## Summary
- fix the Sort-Object parameter to use `-Culture` in the Intune remediation sample script, restoring culture-aware sorting

## Changelog
- not updated (non-functional sample fix)

## Testing
- not run